### PR TITLE
docs: update README to match current app behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,26 @@ Android app for photographing parking receipts, tracking amounts in ZAR, and bul
 
 ## Features
 
-- **Capture receipts** via camera or gallery with amount, date, and optional note
+- **Capture receipts** via camera or gallery, or share an image into the app from other apps
 - **Track unsent/sent** receipts on the home screen with tabbed views and swipe-to-delete
 - **Receipt detail** — view, edit, or delete individual receipts with zoomable photo
 - **Bulk send** — preview selected receipts, generate an A4 PDF (summary page + one page per receipt), and open your email client with everything pre-filled (To, CC, subject, body, PDF attachment)
-- **Friday reminder** notification via WorkManager to prompt weekly submission
-- **Configurable settings** — recipient (To/CC), subject template with `{date_range}`, `{total}`, `{count}` placeholders, and reminder time
+- **Quick Add widget** — add a home screen widget to jump straight to Add Receipt
+- **Friday reminder** — weekly WorkManager reminder at a configurable time (notifies only when unsent receipts exist)
+- **Configurable settings** — From/To/CC emails, subject + PDF filename templates with `{date_range}`, `{total}`, `{count}` placeholders, auto-mark-as-sent, and reminder time
 
 ## Tech Stack
 
-Kotlin · Jetpack Compose · Material 3 · Room · Navigation Compose · CameraX · WorkManager · DataStore · Coil
+Kotlin · Jetpack Compose · Material 3 · Room · Navigation Compose · CameraX · WorkManager · DataStore · Coil · Glance (App Widget) · Kotlin Serialization
 
 ## Build
 
 Open in Android Studio, sync Gradle, run on device/emulator (API 24+).
 
+SDK: min 24 · target 36 · compile 36  
 Requires: AGP 9.0.1, Kotlin 2.0.21, Java 17+, Gradle 9.2.1.
 
 ## Permissions
 
-- **CAMERA** — capture receipt photos
-- **POST_NOTIFICATIONS** — Friday reminder alerts
+- **CAMERA** — capture receipt photos (camera hardware is optional; gallery/share import also supported)
+- **POST_NOTIFICATIONS** — Friday reminder alerts on Android 13+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refresh README feature list to include image share-in flow and the Quick Add home-screen widget
- document current settings options (From/To/CC, subject and PDF filename placeholders, auto-mark-as-sent)
- clarify reminder behavior, SDK targets, tech stack additions, and permission caveats

## Validation
- verified README content against implementation files (`AndroidManifest`, `MainActivity`, settings, reminder worker, and widget code)

Closes #12
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab5d3ec3-4f66-45e4-a127-e299544fb821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab5d3ec3-4f66-45e4-a127-e299544fb821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

